### PR TITLE
Fix terminal state being corrupted if no prompts are executed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,12 +30,12 @@ inThisBuild(
 )
 
 val Versions = new {
-  val Scala3        = "3.3.4"
-  val munit         = "1.0.2"
+  val Scala3        = "3.3.5"
+  val munit         = "1.1.0"
   val scalaVersions = Seq(Scala3)
   val fansi         = "0.5.0"
   val jna           = "5.14.0"
-  val catsEffect    = "3.5.7"
+  val catsEffect    = "3.6.0"
   val osLib         = "0.11.3"
 }
 

--- a/modules/core/src/main/scala/Completion.scala
+++ b/modules/core/src/main/scala/Completion.scala
@@ -42,5 +42,5 @@ object Completion:
     Completion.Fail(CompletionError.Error(msg))
 
 enum CompletionError(msg: String | Null) extends Throwable(msg):
-  case Interrupted extends CompletionError(null)
+  case Interrupted        extends CompletionError(null)
   case Error(msg: String) extends CompletionError(msg)

--- a/modules/core/src/main/scala/Completion.scala
+++ b/modules/core/src/main/scala/Completion.scala
@@ -41,6 +41,6 @@ object Completion:
   private[cue4s] def error(msg: String) =
     Completion.Fail(CompletionError.Error(msg))
 
-enum CompletionError extends Throwable:
-  case Interrupted
-  case Error(msg: String)
+enum CompletionError(msg: String | Null) extends Throwable(msg):
+  case Interrupted extends CompletionError(null)
+  case Error(msg: String) extends CompletionError(msg)

--- a/modules/core/src/main/scalajvm/ChangeModeLinux.java
+++ b/modules/core/src/main/scalajvm/ChangeModeLinux.java
@@ -19,81 +19,82 @@ package cue4s;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Structure;
-import java.util.List;
 import java.util.Arrays;
+import java.util.List;
 
 class ChangeModeLinux implements ChangeMode {
 
-	private static ChangeModeLinux INSTANCE;
+    private static ChangeModeLinux INSTANCE;
 
-	private ChangeModeLinux() {
-	}
+    private ChangeModeLinux() {}
 
-	public static ChangeModeLinux getInstance() {
-		if (INSTANCE == null) {
-			INSTANCE = new ChangeModeLinux();
-		}
+    public static ChangeModeLinux getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new ChangeModeLinux();
+        }
 
-		return INSTANCE;
-	}
+        return INSTANCE;
+    }
 
-	// Define the libc interface
-	private static interface CLibrary extends Library {
-		CLibrary INSTANCE = Native.load("c", CLibrary.class);
+    // Define the libc interface
+    private static interface CLibrary extends Library {
+        CLibrary INSTANCE = Native.load("c", CLibrary.class);
 
-		int tcgetattr(int fd, termios termios);
+        int tcgetattr(int fd, termios termios);
 
-		int tcsetattr(int fd, int optional_actions, termios termios);
+        int tcsetattr(int fd, int optional_actions, termios termios);
 
-		int getchar();
-	}
+        int getchar();
+    }
 
-	// Define the termios structure
-	@Structure.FieldOrder({ "c_iflag", "c_oflag", "c_cflag", "c_lflag", "c_line", "c_cc", "c_ispeed", "c_ospeed" })
-	public static class termios extends Structure {
-		public int c_iflag;
-		public int c_oflag;
-		public int c_cflag;
-		public int c_lflag;
-		public byte c_line;
-		public byte[] c_cc = new byte[32];
-		public int c_ispeed;
-		public int c_ospeed;
-	}
+    // Define the termios structure
+    @Structure.FieldOrder(
+        {
+            "c_iflag",
+            "c_oflag",
+            "c_cflag",
+            "c_lflag",
+            "c_line",
+            "c_cc",
+            "c_ispeed",
+            "c_ospeed",
+        }
+    )
+    public static class termios extends Structure {
 
-	// Constants
-	private static final int STDIN_FILENO = 0;
-	private static final int TCSANOW = 0;
-	private static final int ICANON = 0x0000002;
-	private static final int ECHO = 0x0008;
+        public int c_iflag;
+        public int c_oflag;
+        public int c_cflag;
+        public int c_lflag;
+        public byte c_line;
+        public byte[] c_cc = new byte[32];
+        public int c_ispeed;
+        public int c_ospeed;
+    }
 
-	// Function to change mode
-	private termios oldt = new termios(); // store original termios
+    // Constants
+    private static final int STDIN_FILENO = 0;
+    private static final int TCSANOW = 0;
+    private static final int ICANON = 0x0000002;
+    private static final int ECHO = 0x0008;
 
-	@Override
-	public int getchar() {
-		return CLibrary.INSTANCE.getchar();
-	}
+    @Override
+    public int getchar() {
+        return CLibrary.INSTANCE.getchar();
+    }
 
-	@Override
-	public void changemode(int dir) {
-		termios newt = new termios();
+    @Override
+    public void changemode(int dir) {
+        termios termiosAttrs = new termios();
 
-		if (dir == 1) {
-			CLibrary.INSTANCE.tcgetattr(STDIN_FILENO, oldt); // get current terminal attributes
-			newt.c_iflag = oldt.c_iflag;
-			newt.c_oflag = oldt.c_oflag;
-			newt.c_cflag = oldt.c_cflag;
-			newt.c_lflag = oldt.c_lflag;
-			newt.c_line = oldt.c_line;
-			newt.c_cc = oldt.c_cc;
-			newt.c_ispeed = oldt.c_ispeed;
-			newt.c_ospeed = oldt.c_ospeed;
-
-			newt.c_lflag = newt.c_lflag & ~(ICANON | ECHO); // disable canonical mode and echo
-			CLibrary.INSTANCE.tcsetattr(STDIN_FILENO, TCSANOW, newt); // set new terminal attributes
-		} else {
-			CLibrary.INSTANCE.tcsetattr(STDIN_FILENO, TCSANOW, oldt); // restore original terminal attributes
-		}
-	}
+        if (dir == 1) {
+            CLibrary.INSTANCE.tcgetattr(STDIN_FILENO, termiosAttrs); // get current terminal attributes
+            termiosAttrs.c_lflag = termiosAttrs.c_lflag & ~(ICANON | ECHO); // disable canonical mode and echo
+            CLibrary.INSTANCE.tcsetattr(STDIN_FILENO, TCSANOW, termiosAttrs); // set new terminal attributes
+        } else {
+            CLibrary.INSTANCE.tcgetattr(STDIN_FILENO, termiosAttrs); // get current terminal attributes
+            termiosAttrs.c_lflag = termiosAttrs.c_lflag & (ICANON | ECHO); // re-enable canonical mode and echo
+            CLibrary.INSTANCE.tcsetattr(STDIN_FILENO, TCSANOW, termiosAttrs); // set new terminal attributes
+        }
+    }
 }

--- a/modules/core/src/main/scalanative/ChangeModeLinux.scala
+++ b/modules/core/src/main/scalanative/ChangeModeLinux.scala
@@ -44,24 +44,28 @@ object ChangeModeLinux extends ChangeModeUnix:
     Zone:
       val state = alloc[termios]()
 
+      val isTTY = scalanative.posix.unistd.isatty(STDIN_FILENO) == 2
+
       if rawMode then
         assertAndReturn(
-          Termios.tcgetattr(STDIN_FILENO, state.asInstanceOf) == 0,
+          !isTTY || Termios.tcgetattr(STDIN_FILENO, state.asInstanceOf) == 0,
           "getting current flags failed",
         )
         (!state)._4 = (!state)._4 & ~(ICANON | ECHO)
         assertAndReturn(
-          Termios.tcsetattr(STDIN_FILENO, TCSANOW, state.asInstanceOf) == 0,
+          !isTTY || Termios
+            .tcsetattr(STDIN_FILENO, TCSANOW, state.asInstanceOf) == 0,
           "changing to char input failed",
         )
       else
         assertAndReturn(
-          Termios.tcgetattr(STDIN_FILENO, state.asInstanceOf) == 0,
+          !isTTY || Termios.tcgetattr(STDIN_FILENO, state.asInstanceOf) == 0,
           "getting current flags failed",
         )
         state._4 = (!state)._4 & (ICANON | ECHO)
         assertAndReturn(
-          Termios.tcsetattr(STDIN_FILENO, TCSANOW, state.asInstanceOf) == 0,
+          !isTTY || Termios
+            .tcsetattr(STDIN_FILENO, TCSANOW, state.asInstanceOf) == 0,
           "changing back from char input failed",
         )
       end if

--- a/modules/core/src/main/scalanative/ChangeModeLinux.scala
+++ b/modules/core/src/main/scalanative/ChangeModeLinux.scala
@@ -24,13 +24,13 @@ object ChangeModeLinux extends ChangeModeUnix:
 
   import scalanative.posix.termios.{TCSANOW, ECHO, ICANON}
   import scalanative.unsafe.Nat.*
-  type tcflag_t = CInt /// SIC!!!
-  type cc_t     = CChar
-  type speed_t  = CInt /// SIC!!!
-  type NCCS     = Digit2[_3, _2]
-  type c_cc     = CArray[cc_t, NCCS]
+  private type tcflag_t = CInt /// SIC!!!
+  private type cc_t     = CChar
+  private type speed_t  = CInt /// SIC!!!
+  private type NCCS     = Digit2[_3, _2]
+  private type c_cc     = CArray[cc_t, NCCS]
 
-  type termios = CStruct7[
+  private type termios = CStruct7[
     tcflag_t, /* c_iflag - input flags   */
     tcflag_t, /* c_oflag - output flags  */
     tcflag_t, /* c_cflag - control flags */
@@ -40,36 +40,31 @@ object ChangeModeLinux extends ChangeModeUnix:
     speed_t,  /* c_ospeed - output speed  */
   ]
 
-  var flags = Option.empty[Int]
-
   def changeMode(rawMode: Boolean): Boolean =
     Zone:
       val state = alloc[termios]()
 
-      import util.boundary
-
-      boundary:
-        inline def assert0(value: Int) =
-          if value != 0 then boundary.break(false)
-          else true
-
-        if rawMode then
-          assert0(Termios.tcgetattr(STDIN_FILENO, state.asInstanceOf))
-          this.synchronized:
-            flags = Some((!state)._4)
-          (!state)._4 = (!state)._4 & ~(ICANON | ECHO)
-          assert0(Termios.tcsetattr(STDIN_FILENO, TCSANOW, state.asInstanceOf))
-        else
-          flags.foreach: oldflags =>
-            assert0(Termios.tcgetattr(STDIN_FILENO, state.asInstanceOf))
-            (!state)._4 = oldflags
-            this.synchronized:
-              flags = None
-            assert0(
-              Termios.tcsetattr(STDIN_FILENO, TCSANOW, state.asInstanceOf),
-            )
-          true
-        end if
+      if rawMode then
+        assertAndReturn(
+          Termios.tcgetattr(STDIN_FILENO, state.asInstanceOf) == 0,
+          "getting current flags failed",
+        )
+        (!state)._4 = (!state)._4 & ~(ICANON | ECHO)
+        assertAndReturn(
+          Termios.tcsetattr(STDIN_FILENO, TCSANOW, state.asInstanceOf) == 0,
+          "changing to char input failed",
+        )
+      else
+        assertAndReturn(
+          Termios.tcgetattr(STDIN_FILENO, state.asInstanceOf) == 0,
+          "getting current flags failed",
+        )
+        state._4 = (!state)._4 & (ICANON | ECHO)
+        assertAndReturn(
+          Termios.tcsetattr(STDIN_FILENO, TCSANOW, state.asInstanceOf) == 0,
+          "changing back from char input failed",
+        )
+      end if
   end changeMode
 
 end ChangeModeLinux

--- a/modules/core/src/main/scalanative/ChangeModeUnix.scala
+++ b/modules/core/src/main/scalanative/ChangeModeUnix.scala
@@ -22,16 +22,11 @@ trait ChangeModeUnix extends ChangeModeNative:
   val STDIN_FILENO = 0
 
   def getchar(): Int =
-    val c = scalanative.libc.stdio.getchar()
-    if c == -1 then 
-      println(scalanative.libc.errno.errno)
-    c
-
+    scalanative.libc.stdio.getchar()
 
   protected inline def assertAndReturn(b: Boolean, msg: String) =
     assert(b, msg)
     b
-
 
 end ChangeModeUnix
 

--- a/modules/core/src/main/scalanative/ChangeModeUnix.scala
+++ b/modules/core/src/main/scalanative/ChangeModeUnix.scala
@@ -22,7 +22,16 @@ trait ChangeModeUnix extends ChangeModeNative:
   val STDIN_FILENO = 0
 
   def getchar(): Int =
-    scalanative.libc.stdio.getchar()
+    val c = scalanative.libc.stdio.getchar()
+    if c == -1 then 
+      println(scalanative.libc.errno.errno)
+    c
+
+
+  protected inline def assertAndReturn(b: Boolean, msg: String) =
+    assert(b, msg)
+    b
+
 
 end ChangeModeUnix
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.5
+sbt.version=1.10.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.1")
 // Scala.js and Scala Native
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.6")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.7")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.1")
 
 // Scala.js and Scala Native
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.18.2")
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.7")
 


### PR DESCRIPTION
I noticed that in cases where we start input provider, but don't actually run `changeMode` the first time, we will run it incorrectly upon closing of the provider, setting a bunch of flags to 0s and corrupting terminal state.
After that terminal is corrupted beyond repair, not even `stty sane` can bring it back (reading from stdin returns -1)